### PR TITLE
README.rst: Fix title underline too short

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 CellarDoor
-=======
+==========
 
 |Build Status| |Coverage Status|
 


### PR DESCRIPTION
Probably fixes rendering on PyPI (#1)?
