### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ CellarDoor
 CellarDoor is a framework for building CRUD APIs mostly declaratively. It includes data modeling, data storage, authentication, authorization, serialization and interface protocols. It aims to dramatically reduce repetitive effort without getting in the way of the interesting bits of your application.
 
 
-.. |PyPI| image:: https://pypip.in/version/cellardoor/badge.svg?style=flat
+.. |PyPI| image:: https://img.shields.io/pypi/v/cellardoor.svg?style=flat
    :target: https://pypi.python.org/pypi/cellardoor/
 
 .. |Build Status| image:: https://travis-ci.org/cooper-software/cellardoor.svg


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20cellardoor))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `cellardoor`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.